### PR TITLE
fix: image Repository deleteAllByInformationId 누락

### DIFF
--- a/src/main/java/solitour_backend/solitour/image/repository/ImageRepository.java
+++ b/src/main/java/solitour_backend/solitour/image/repository/ImageRepository.java
@@ -16,4 +16,5 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     void deleteByAddress(String address);
 
+    void deleteAllByInformationId(Long informationId);
 }


### PR DESCRIPTION
information 삭제시 해당 image 모두 삭제

