### PR TITLE
Feature/information detail v2 - api 2개로 나누기

### DIFF
--- a/src/main/java/solitour_backend/solitour/error/exception/RequestValidationFailedException.java
+++ b/src/main/java/solitour_backend/solitour/error/exception/RequestValidationFailedException.java
@@ -20,4 +20,9 @@ public class RequestValidationFailedException extends ValidationException {
                         .append(objectError.getCode()))
                 .collect(Collectors.joining("|")));
     }
+
+
+    public RequestValidationFailedException(String message) {
+        super(message);
+    }
 }

--- a/src/main/java/solitour_backend/solitour/information/controller/InformationController.java
+++ b/src/main/java/solitour_backend/solitour/information/controller/InformationController.java
@@ -61,6 +61,19 @@ public class InformationController {
                 .body(informationDetailResponse);
     }
 
+    @GetMapping("/{informationId}/recommend/{categoryId}")
+    public ResponseEntity<List<InformationBriefResponse>> getRecommendInformation(@PathVariable Long informationId,
+                                                                                  @PathVariable Long categoryId,
+                                                                                  HttpServletRequest request) {
+
+        Long userId = findUser(request);
+        List<InformationBriefResponse> recommendInformation = informationService.getRecommendInformation(categoryId, informationId, userId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(recommendInformation);
+    }
+
     @Authenticated
     @PutMapping("/{informationId}")
     public ResponseEntity<InformationResponse> modifyInformation(@PathVariable Long informationId,

--- a/src/main/java/solitour_backend/solitour/information/dto/response/InformationDetailResponse.java
+++ b/src/main/java/solitour_backend/solitour/information/dto/response/InformationDetailResponse.java
@@ -30,6 +30,4 @@ public class InformationDetailResponse {
 
     private List<ImageResponse> imageResponses;
     private int likeCount;
-
-    private List<InformationBriefResponse> recommendInformation;
 }

--- a/src/main/java/solitour_backend/solitour/information/service/InformationService.java
+++ b/src/main/java/solitour_backend/solitour/information/service/InformationService.java
@@ -10,6 +10,7 @@ import solitour_backend.solitour.book_mark_information.entity.BookMarkInformatio
 import solitour_backend.solitour.category.entity.Category;
 import solitour_backend.solitour.category.exception.CategoryNotExistsException;
 import solitour_backend.solitour.category.repository.CategoryRepository;
+import solitour_backend.solitour.error.exception.RequestValidationFailedException;
 import solitour_backend.solitour.great_information.repository.GreatInformationRepository;
 import solitour_backend.solitour.image.dto.mapper.ImageMapper;
 import solitour_backend.solitour.image.dto.request.ImageDeleteRequest;
@@ -174,8 +175,6 @@ public class InformationService {
 
         int likeCount = greatInformationRepository.countByInformationId(information.getId());
 
-        List<InformationBriefResponse> informationRecommendList = informationRepository.getInformationRecommend(information.getId(), information.getCategory().getId(), userId);
-
         return new InformationDetailResponse(
                 information.getTitle(),
                 information.getAddress(),
@@ -188,8 +187,20 @@ public class InformationService {
                 placeResponse,
                 zoneCategoryResponse,
                 imageResponseList,
-                likeCount,
-                informationRecommendList);
+                likeCount);
+    }
+
+    public List<InformationBriefResponse> getRecommendInformation(Long informationId, Long categoryId, Long userId) {
+        Information information = informationRepository.findById(informationId)
+                .orElseThrow(
+                        () -> new InformationNotExistsException("해당하는 id의 information 이 존재하지 않습니다")
+                );
+
+        if (!information.getCategory().getId().equals(categoryId)) {
+            throw new RequestValidationFailedException("해당하는 정보의 카테고리와 일치하지 않습니다");
+        }
+
+        return informationRepository.getInformationRecommend(informationId, categoryId, userId);
     }
 
 


### PR DESCRIPTION
- 제목 : Feat(#50): 상세페이지 api 2개로 나누기  

## 📝작업 내용

기존의 정보 상세페이지 api 
상세정보 + 하단의 추천 정보 3개 
이렇게 있던걸

상세정보 api
하단의 추천정보 api 
나누기 

## #️⃣연관된 이슈

#50 
