### PR TITLE
Fix(#216) : 유저, 일기 이미지 자동삭제 되지 않게 수정

### DIFF
--- a/src/main/java/solitour_backend/solitour/diary/service/DiaryService.java
+++ b/src/main/java/solitour_backend/solitour/diary/service/DiaryService.java
@@ -103,6 +103,7 @@ public class DiaryService {
 
     private void saveDiaryDayContent(Diary savedDiary, DiaryCreateRequest request) {
         for (DiaryDayRequest dayRequest : request.getDiaryDayRequests()) {
+            s3Uploader.markImagePermanent(dayRequest.getDiaryDayContentImages());
             DiaryDayContent diaryDayContent = DiaryDayContent.builder()
                     .diary(savedDiary)
                     .content(dayRequest.getContent())

--- a/src/main/java/solitour_backend/solitour/user_image/service/UserImageService.java
+++ b/src/main/java/solitour_backend/solitour/user_image/service/UserImageService.java
@@ -32,6 +32,7 @@ public class UserImageService {
     public UserImageResponse updateUserProfile(Long userId, MultipartFile userImage) {
 
         String userImageUrl = s3Uploader.upload(userImage, IMAGE_PATH, userId);
+        s3Uploader.markImagePermanent(userImageUrl);
 
         return new UserImageResponse(userImageUrl);
     }


### PR DESCRIPTION
## 📝작업 내용

유저, 일기 이미지가 하루 지나면 자동으로 삭제되는 문제 해결

## #️⃣연관된 이슈

#216